### PR TITLE
Indexed event param

### DIFF
--- a/crates/ast/src/parser.rs
+++ b/crates/ast/src/parser.rs
@@ -820,6 +820,22 @@ mod tests {
                 rets: Box::new([(DynSolType::parse("uint256").unwrap(), span)]),
             })
         );
+        assert_err!(
+            sol_function(),
+            vec![
+                Ident("function"),
+                Ident("balanceOf"),
+                Punct('('),
+                Ident("address"),
+                Ident("indexed"),
+                Punct(')'),
+                Ident("returns"),
+                Punct('('),
+                Ident("uint256"),
+                Punct(')')
+            ],
+            "word overflows"
+        );
     }
 
     #[test]
@@ -855,10 +871,14 @@ mod tests {
                 Punct('('),
                 Ident("address"),
                 Ident("indexed"),
+                Ident("sender"),
                 Punct(','),
                 Ident("address"),
+                Ident("indexed"),
+                Ident("recipient"),
                 Punct(','),
                 Ident("uint256"),
+                Ident("amount"),
                 Punct(')')
             ],
             ast::Definition::SolEvent(ast::SolEvent {

--- a/crates/ast/src/parser.rs
+++ b/crates/ast/src/parser.rs
@@ -816,6 +816,34 @@ mod tests {
     }
 
     #[test]
+    fn parse_sol_event_indexed() {
+        let span: Span = SimpleSpan::new(0, 0);
+        assert_ok!(
+            sol_event(),
+            vec![
+                Ident("event"),
+                Ident("Transfer"),
+                Punct('('),
+                Ident("address"),
+                Ident("indexed"),
+                Punct(','),
+                Ident("address"),
+                Punct(','),
+                Ident("uint256"),
+                Punct(')')
+            ],
+            ast::Definition::SolEvent(ast::SolEvent {
+                name: ("Transfer", span),
+                args: Box::new([
+                    (DynSolType::parse("address").unwrap(), span),
+                    (DynSolType::parse("address").unwrap(), span),
+                    (DynSolType::parse("uint256").unwrap(), span),
+                ]),
+            })
+        );
+    }
+
+    #[test]
     fn parse_sol_error() {
         let span: Span = SimpleSpan::new(0, 0);
 

--- a/crates/ast/src/parser.rs
+++ b/crates/ast/src/parser.rs
@@ -847,11 +847,6 @@ mod tests {
                 ]),
             })
         );
-    }
-
-    #[test]
-    fn parse_sol_event_indexed() {
-        let span: Span = SimpleSpan::new(0, 0);
         assert_ok!(
             sol_event(),
             vec![


### PR DESCRIPTION
Adds support for `indexed` event parameters when declared with `#define`.